### PR TITLE
Add information for postponed games

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.4 - 2020-01-24
+
+### Added
+- Display POSTP. for games that have been postponed
+
 ## 0.2.3 - 2020-01-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,8 @@ fn print_game(game: &Game) {
         white_ln!("{:>6}", game.score);
     } else if game.status == "FINAL" {
         green_ln!("{:>6}", format!("{} {}", game.special, game.score));
+    } else if game.status == "POSTPONED" {
+        white_ln!("{:>6}", "POSTP.");
     }
 
     // Print scores


### PR DESCRIPTION
If game is postponed, instead of empty score, this adds "POSTP." in the score column to make it clear the game is not gonna happen.