### PR TITLE
Add support for playoffs overtime

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.5 - 2020-01-29
+
+### Added
+- Support for playoff overtimes
+
 ## 0.2.4 - 2020-01-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "colour",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,7 @@ mod tests {
         let missing_data = r#"{ "team": "CHI" }"#;
         let playoff_ot = r#"{ "team": "CHI", "period": "4" }"#;
         let playoff_ot_2 = r#"{ "team": "CHI", "period": "10" }"#;
+        let wrong_data = r#"{ "team": "CHI", "period": "SP" }"#;
 
         let goal1: serde_json::Value = serde_json::from_str(&first)?;
         let goal2: serde_json::Value = serde_json::from_str(&second)?;
@@ -345,6 +346,7 @@ mod tests {
         let goal6: serde_json::Value = serde_json::from_str(&missing_data)?;
         let goal7: serde_json::Value = serde_json::from_str(&playoff_ot)?;
         let goal8: serde_json::Value = serde_json::from_str(&playoff_ot_2)?;
+        let goal9: serde_json::Value = serde_json::from_str(&wrong_data)?;
 
         assert_eq!(is_special(&goal1), false);
         assert_eq!(is_special(&goal2), false);
@@ -354,6 +356,9 @@ mod tests {
         assert_eq!(is_special(&goal6), false);
         assert_eq!(is_special(&goal7), true);
         assert_eq!(is_special(&goal8), true);
+        // I haven't yet really decided what this should be but
+        // important thing is that it does not crash the app
+        assert_eq!(is_special(&goal9), true);
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,15 +127,10 @@ fn format_minute(min: u64, period: &str) -> u64 {
 fn is_special(goal: &serde_json::Value) -> bool {
     let period = goal["period"].as_str();
     match period {
-        Some(period) => {
-            let is_ot = period == "OT";
-            let is_so = period == "SO";
-            let is_playoff_ot = match period.parse::<u64>() {
-                Ok(period) => period >= 4,
-                Err(_) => false,
-            };
-            is_ot || is_so || is_playoff_ot
-        }
+        Some(period) => match period.parse::<u64>() {
+            Ok(period) => period >= 4,
+            Err(_) => true,
+        },
         None => false,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,11 @@ fn is_special(goal: &serde_json::Value) -> bool {
         Some(period) => {
             let is_ot = period == "OT";
             let is_so = period == "SO";
-            is_ot || is_so
+            let is_playoff_ot = match period.parse::<u64>() {
+                Ok(period) => period >= 4,
+                Err(_) => false,
+            };
+            is_ot || is_so || is_playoff_ot
         }
         None => false,
     }
@@ -335,6 +339,8 @@ mod tests {
         let overtime = r#"{ "team": "CHI", "period": "OT" }"#;
         let shootout = r#"{ "team": "CHI", "period": "SO" }"#;
         let missing_data = r#"{ "team": "CHI" }"#;
+        let playoff_ot = r#"{ "team": "CHI", "period": "4" }"#;
+        let playoff_ot_2 = r#"{ "team": "CHI", "period": "10" }"#;
 
         let goal1: serde_json::Value = serde_json::from_str(&first)?;
         let goal2: serde_json::Value = serde_json::from_str(&second)?;
@@ -342,6 +348,8 @@ mod tests {
         let goal4: serde_json::Value = serde_json::from_str(&overtime)?;
         let goal5: serde_json::Value = serde_json::from_str(&shootout)?;
         let goal6: serde_json::Value = serde_json::from_str(&missing_data)?;
+        let goal7: serde_json::Value = serde_json::from_str(&playoff_ot)?;
+        let goal8: serde_json::Value = serde_json::from_str(&playoff_ot_2)?;
 
         assert_eq!(is_special(&goal1), false);
         assert_eq!(is_special(&goal2), false);
@@ -349,6 +357,8 @@ mod tests {
         assert_eq!(is_special(&goal4), true);
         assert_eq!(is_special(&goal5), true);
         assert_eq!(is_special(&goal6), false);
+        assert_eq!(is_special(&goal7), true);
+        assert_eq!(is_special(&goal8), true);
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,12 +116,11 @@ async fn api() -> Result<(), Error> {
 }
 
 fn format_minute(min: u64, period: &str) -> u64 {
-    match period {
-        "1" => min,
-        "2" => 20 + min,
-        "3" => 40 + min,
-        "OT" => 60 + min,
-        _ => min,
+    if period == "OT" {
+        60 + min
+    } else {
+        let numeric_period: u64 = period.parse().unwrap();
+        20 * (numeric_period - 1) + min
     }
 }
 
@@ -318,6 +317,9 @@ mod tests {
         assert_eq!(format_minute(3, "1"), 3);
         assert_eq!(format_minute(13, "2"), 33);
         assert_eq!(format_minute(5, "3"), 45);
+        assert_eq!(format_minute(12, "4"), 72);
+        assert_eq!(format_minute(5, "5"), 85);
+        assert_eq!(format_minute(5, "6"), 105);
         assert_eq!(format_minute(4, "OT"), 64);
         assert_eq!(format_minute(0, "1"), 0);
         assert_eq!(format_minute(0, "2"), 20);


### PR DESCRIPTION
In API docs, it says

> Note on overtimes: Only regular season 5 minute overtimes are considered "overtime" in the goals array. Playoff overtime periods are returned as period 4, 5, and so on, since they are 20 minute periods. However, all games (including playoff games) that went into overtime are marked as having ended in overtime in the scores object.

This pull request treats any period after 3 as overtime period and adds support for calculating goal minutes correctly for overtime playoffs.

Closes #18 