### PR TITLE
Add functionality to disable colors 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0 - 2020-01-29
+
+### Added
+- A flag `--nocolors` that allows users to turn off the colors
+
+### Changed
+- When printing elsewhere than standard out, colors are disabled
+
 ## 0.2.5 - 2020-01-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
 name = "nhl-235"
 version = "0.2.5"
 dependencies = [
+ "atty",
  "colour",
  "itertools",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3.13"
+atty = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ extern crate colour;
 use reqwest::Error;
 use serde_json;
 use structopt::StructOpt;
+use atty::Stream;
 
 use itertools::{EitherOrBoth::*, Itertools};
 
@@ -255,19 +256,36 @@ fn print_game(game: &Game) {
     }
 
     // Print header
-    white!(
-        "{:<15} {:>2} {:<15} {:<2} ",
-        translate_team_name(&game.home[..]),
-        '-',
-        translate_team_name(&game.away[..]),
-        ""
-    );
-    if game.status == "LIVE" {
-        white_ln!("{:>6}", game.score);
-    } else if game.status == "FINAL" {
-        green_ln!("{:>6}", format!("{} {}", game.special, game.score));
-    } else if game.status == "POSTPONED" {
-        white_ln!("{:>6}", "POSTP.");
+    if atty::is(Stream::Stdout) {
+        white!(
+            "{:<15} {:>2} {:<15} {:<2} ",
+            translate_team_name(&game.home[..]),
+            '-',
+            translate_team_name(&game.away[..]),
+            ""
+        );
+        if game.status == "LIVE" {
+            white_ln!("{:>6}", game.score);
+        } else if game.status == "FINAL" {
+            green_ln!("{:>6}", format!("{} {}", game.special, game.score));
+        } else if game.status == "POSTPONED" {
+            white_ln!("{:>6}", "POSTP.");
+        }
+    } else {
+        print!(
+            "{:<15} {:>2} {:<15} {:<2} ",
+            translate_team_name(&game.home[..]),
+            '-',
+            translate_team_name(&game.away[..]),
+            ""
+        );
+        if game.status == "LIVE" {
+            println!("{:>6}", game.score);
+        } else if game.status == "FINAL" {
+            println!("{:>6}", format!("{} {}", game.special, game.score));
+        } else if game.status == "POSTPONED" {
+            println!("{:>6}", "POSTP.");
+        }
     }
 
     // Print scores
@@ -295,26 +313,38 @@ fn print_game(game: &Game) {
 
 fn print_both_goals(home: &Goal, away: &Goal) {
     let home_message = format!("{:<15} {:>2} ", home.scorer, home.minute);
-    if home.special {
-        magenta!("{}", home_message);
+    if atty::is(Stream::Stdout) {
+        if home.special {
+            magenta!("{}", home_message);
+        } else {
+            cyan!("{}", home_message);
+        }
     } else {
-        cyan!("{}", home_message);
+        print!("{}", home_message);
     }
 
     let away_message = format!("{:<15} {:>2}", away.scorer, away.minute);
-    if away.special {
-        magenta_ln!("{}", away_message);
+    if atty::is(Stream::Stdout) {
+        if away.special {
+            magenta_ln!("{}", away_message);
+        } else {
+            cyan_ln!("{}", away_message);
+        }
     } else {
-        cyan_ln!("{}", away_message);
+        println!("{}", away_message);
     }
 }
 
 fn print_home_goal(home: &Goal) {
     let message = format!("{:<15} {:>2}", home.scorer, home.minute);
-    if home.special {
-        magenta_ln!("{}", message);
+    if atty::is(Stream::Stdout) {
+        if home.special {
+            magenta_ln!("{}", message);
+        } else {
+            cyan_ln!("{}", message);
+        }
     } else {
-        cyan_ln!("{}", message);
+        println!("{}", message);
     }
 }
 
@@ -323,10 +353,14 @@ fn print_away_goal(away: &Goal) {
         "{:<15} {:>2} {:<15} {:>2}",
         "", "", away.scorer, away.minute
     );
-    if away.special {
-        magenta_ln!("{}", message);
+    if atty::is(Stream::Stdout) {
+        if away.special {
+            magenta_ln!("{}", message);
+        } else {
+            cyan_ln!("{}", message);
+        }
     } else {
-        cyan_ln!("{}", message);
+        println!("{}", message);
     }
 }
 


### PR DESCRIPTION
## What it does?

This pull request does two things related to colors:

1. When printing elsewhere than standard out, disable colors

This enables redirecting output to file or piping it to another command.

2. Add a flag `--nocolors` that turns off colors when printing to stdout

With colors:
![Screenshot 2021-02-10 at 18 12 11](https://user-images.githubusercontent.com/1909996/107537709-df128c80-6bcb-11eb-8d6e-e633ab80f662.png)

Without colors:
![Screenshot 2021-02-10 at 18 12 32](https://user-images.githubusercontent.com/1909996/107537719-e2a61380-6bcb-11eb-98a1-babfd73108f1.png)

## Why?

When piping to other applications, sending color information just makes a mess and makes the output unsaveable with files or unusable as input to other applications.

Also, adding the ability to do that with a flag allows people who don't like colors or who use terminals that don't support colors very well to enjoy using the application.

## Dependencies

Introduces a new dependency, [atty](https://crates.io/crates/atty) for detecting output target of the script.

Fixes #20 