### PR TITLE
Add graceful error handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "0.2.5"
+version = "1.0.0"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "0.3.0"
+version = "1.0.0"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,11 @@
 
 #[macro_use]
 extern crate colour;
+use atty::Stream;
 use reqwest::Error;
 use serde_json;
+use std::process;
 use structopt::StructOpt;
-use atty::Stream;
 
 use itertools::{EitherOrBoth::*, Itertools};
 
@@ -59,8 +60,24 @@ fn main() {
                 let parsed_games = parse_games(scores);
                 print_games(parsed_games, use_colors);
             }
-            Err(err) => println!("{:?}", err),
+            Err(err) => {
+                handle_request_error(err);
+            }
         };
+    }
+}
+
+fn handle_request_error(e: reqwest::Error) {
+    if e.is_connect() {
+        println!("ERROR: Can't connect to the API. It might be because your Internet connection is down.");
+        process::exit(1);
+    } else if e.is_timeout() {
+        println!("ERROR: API timed out. Try again later.");
+        process::exit(1);
+    } else {
+        println!("ERROR: Unknown error.");
+        println!("{:?}", e);
+        process::exit(1);
     }
 }
 


### PR DESCRIPTION
For cases where there's no internet connection or the API request times out, tell that to the user. In other cases, print a generic error message + original error trace.

So far, the only error case I've been able to reproduce is lack of internet connection so I'll add the other cases as they arise.

Also, version 1.0.0! :tada: