### PR TITLE
Add line break after playoff score

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -331,7 +331,7 @@ fn print_game(game: &Game, use_colors: bool) {
             let away_wins = &series_wins[&game.away];
 
             if atty::is(Stream::Stdout) && use_colors {
-                yellow!("Series {}-{}", home_wins, away_wins);
+                yellow_ln!("Series {}-{}", home_wins, away_wins);
             } else {
                 println!("Series {}-{}", home_wins, away_wins);
             }


### PR DESCRIPTION
I accidentally used `yellow!` instead of `yellow_ln!` and the layout got messed up with more than one game.