### PR TITLE
Bugfix: Correctly display playoff overtime goals scored at 66th minute

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.4 - 2021-06-04
+
+### Fixed
+- A bug where playoff overtime goal scored at 65 minutes would not show up.
+
 ## 1.0.2 - 2021-05-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,12 +255,20 @@ fn print_game(game: &Game, use_colors: bool) {
     let home_scores: Vec<&Goal> = game
         .goals
         .iter()
-        .filter(|goal| goal.team == game.home && goal.minute != SHOOTOUT_MINUTE)
+        .filter(|goal| {
+            goal.team == game.home
+                && (goal.minute != SHOOTOUT_MINUTE
+                    || goal.minute == SHOOTOUT_MINUTE && game.special == "ot")
+        })
         .collect::<Vec<&Goal>>();
     let away_scores: Vec<&Goal> = game
         .goals
         .iter()
-        .filter(|goal| goal.team == game.away && goal.minute != SHOOTOUT_MINUTE)
+        .filter(|goal| {
+            goal.team == game.away
+                && (goal.minute != SHOOTOUT_MINUTE
+                    || goal.minute == SHOOTOUT_MINUTE && game.special == "ot")
+        })
         .collect::<Vec<&Goal>>();
 
     let mut shootout_scorer = None;


### PR DESCRIPTION
The code had a bug that if an overtime goal was scored in a playoff game at minute 65,
the goal wouldn't show up in the output. This was because I initially treated 65 as a shootout
goal minute and for those, only want to show the last one.

However, since the goal was not a shootout goal, it would get discarded originally and then never printed.

Fixes #22