### PR TITLE
Add support for configurable highlights for individual players

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.0 - 2022-03-04
+
+### Added
+
+- Support for configurable highlight feature for individual players
+
 ## 1.1.1 - 2021-11-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,10 +632,11 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "atty",
  "colour",
+ "dirs",
  "itertools",
  "reqwest",
  "serde",
@@ -896,6 +917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -20,3 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3.13"
 atty = "0.2"
+dirs = "4.0"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Store the file with filename `235` in a folder that is in the path.
 235
 ```
 
+### Highlight favorite players
+
+235 (from `1.2.0` onwards) supports configurable highlights of individual players.
+
+To do this, you first need to create a config file to your home directory called `.235.config` and then call the script with
+
+```
+235 --highlight
+```
+
 ### Current version
 
 ```


### PR DESCRIPTION
The background for this is that often I want to see if certain players have scored during the round. The original Yle TekstiTV service did that for all the Finnish players but since the API this project uses doesn't have nationality data and to be more usable for non-Finns, I decided to make this with completely customizable configuration so everyone can choose their favourite players to follow.

Requires two steps to work from user:

1. A config file `.235.config` located in home folder. One last name per line.
 
<img width="342" alt="Output of file ~/.235.config with two lines, Crosby and Toews" src="https://user-images.githubusercontent.com/1909996/156771555-ba133c9c-f092-40dd-bb8a-28783cbec5da.png">

2. Running with `--highlight` flag
<img width="368" alt="Scores output with Crosby's goal highlighted in yellow with other scores in magenta" src="https://user-images.githubusercontent.com/1909996/156771793-d6aafe13-aa2d-4c86-a152-6278883decdb.png">

Implements #37.