### PR TITLE
Fix errors when date is null

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.1 - 2022-09-26
+
+### Fixed
+
+- Fix errors for when date is null.
+
 ## 1.2.0 - 2022-03-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/api_types.rs
+++ b/src/api_types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct APIResponse {
-    pub date: DateResponse,
+    pub date: Option<DateResponse>,
     pub games: Vec<GameResponse>,
     pub errors: Option<HashMap<String, serde_json::Value>>,
 }


### PR DESCRIPTION
The date field is documented to be a string but can also be a null.

Sincc we don't use date field for anything, I just made it optional to surpress those errors.