### PR TITLE
New feature: show stats for followed players with `--stats`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0 - 2023-10-21
+
+### Added
+
+- Added `--stats` flag
+
 ## 1.2.2 - 2022-10-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ To do this, you first need to create a config file to your home directory called
 235 --highlight
 ```
 
+### Show player stats for favorite players
+
+From `1.3.0` onwards, you can see your favorite players' game stats (goals + assists) by defining those players in `$HOME/.235.config` (a list of last names, one per line) and running
+
+```
+235 --stats
+```
+
 ### Current version
 
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,13 @@
         </p>
       </section>
       <section>
+        <h2>Release notes</h2>
+
+        <ul class="release-notes">
+          <li><a href="release-notes/1.3.0">version 1.3.0</a></li>
+        </ul>
+      </section>
+      <section>
         <h2>Install:</h2>
         <h3>- with <a href="https://crates.io/">Rust</a></h3>
         <pre><code>cargo install nhl-235
@@ -158,6 +165,57 @@ Crosby</code></pre>
           <em
             >If <code>--nocolors</code> is enabled,
             <code>--highlight</code> does nothing.</em
+          >
+        </p>
+
+        <h3 id="docs-stats">--stats</h3>
+        <p>
+          <em
+            >from version 1.3.0 onwards, see
+            <a href="release-notes/1.3.0.html">release notes</a></em
+          >.
+        </p>
+        <p>
+          You can gain more stats of favorite players by creating a
+          <code>.235.config</code> file in your home directory. Each line in the
+          file must be a single last name to be shown.
+        </p>
+        <p>Example <code>.235.config</code>:</p>
+        <pre><code>Vrana
+Crosby</code></pre>
+        <p>
+          Once run with <code>--stats</code> option, those players' stats will
+          be shown below the game summary if they gain any goals or assists.
+        </p>
+        <pre><code>235 --stats</code></pre>
+        <div class="output-example">
+          <pre>
+<span class="token-prompt">$</span> 235 --highlight
+<span class="token-teams">Washington      - Buffalo</span>          <span class="token-final-score">so 4-3</span>
+<span class="token-player">Backström      16 Staal          12</span>
+<span class="token-player">Dowd           24 Cozens         30</span>
+<span class="token-player">Vrana          33</span> <span class="token-player">Sheahan        33</span>
+<span class="token-shootout">Carlson        65</span>
+
+<span class="token-player">(Vrana 1+1)</span>
+
+
+<span class="token-teams">Pittsburgh      - NY Rangers</span>       1-0
+<span class="token-player">Crosby         14</span>
+
+<span class="token-player">(Crosby 1+0)</span>
+                    </pre>
+        </div>
+        <p>
+          <em
+            >Can be used with <code>--highlight</code> in which case the stats
+            line will be highlighted too.</em
+          >
+        </p>
+        <p>
+          <em
+            >If no players are defined in <code>$HOME/.235.config</code>, this
+            option does nothing.</em
           >
         </p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,61 +1,82 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>235 - hockey results with a familiar feel</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap"
+      rel="stylesheet"
+    />
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>235 - hockey results with a familiar feel</title>
-  <link rel="preconnect" href="https://fonts.gstatic.com" />
-  <link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet" />
+    <meta
+      property="og:title"
+      content="235 - hockey results with a familiar feel"
+    />
+    <meta property="og:url" content="https://hamatti.github.io/nhl-235" />
+    <meta
+      property="og:description"
+      content="A CLI tool to get NHL results to your terminal with a familiar 235 feeling"
+    />
+    <meta
+      property="og:image"
+      content="https://hamatti.github.io/nhl-235-banner.png"
+    />
 
-  <meta property="og:title" content="235 - hockey results with a familiar feel" />
-  <meta property="og:url" content="https://hamatti.github.io/nhl-235" />
-  <meta property="og:description"
-    content="A CLI tool to get NHL results to your terminal with a familiar 235 feeling" />
-  <meta property="og:image" content="https://hamatti.github.io/nhl-235-banner.png" />
+    <link rel="stylesheet" href="main.css" />
+  </head>
 
-  <link rel="stylesheet" href="main.css" />
-</head>
+  <body>
+    <header>
+      <img src="nhl-235-banner.png" alt="" />
+      <h1>235</h1>
+      <p class="tagline">hockey results with a familiar feel</p>
+    </header>
+    <main>
+      <section>
+        <p>Get your NHL results directly to your terminal.</p>
 
-<body>
-  <header>
-    <img src="nhl-235-banner.png" alt="" />
-    <h1>235</h1>
-    <p class="tagline">hockey results with a familiar feel</p>
-  </header>
-  <main>
-    <section>
-      <p>Get your NHL results directly to your terminal.</p>
-
-      <p>
-        For decades, 235 has been part of a morning routine for countless
-        Finnish hockey fans. This project has been inspired by the work done by
-        <a href="https://yle.fi/aihe/tekstitv?P=235" target="_blank" rel="nofollow noreferrer">YLE Tekstitv</a> team in
-        providing hockey fans NHL results each night and
-        morning.
-      </p>
-    </section>
-    <section>
-      <h2>Install:</h2>
-      <h3>- with <a href="https://crates.io/">Rust</a></h3>
-      <pre><code>cargo install nhl-235
+        <p>
+          For decades, 235 has been part of a morning routine for countless
+          Finnish hockey fans. This project has been inspired by the work done
+          by
+          <a
+            href="https://yle.fi/aihe/tekstitv?P=235"
+            target="_blank"
+            rel="nofollow noreferrer"
+            >YLE Tekstitv</a
+          >
+          team in providing hockey fans NHL results each night and morning.
+        </p>
+      </section>
+      <section>
+        <h2>Install:</h2>
+        <h3>- with <a href="https://crates.io/">Rust</a></h3>
+        <pre><code>cargo install nhl-235
 // To run it with 235 instead of nhl-235:
 ln -s ~/.cargo/bin/nhl-235 /usr/local/bin/235</code></pre>
-      <h3>- from Github</h3>
-      <p>
-        <a href="https://github.com/Hamatti/nhl-235/releases/latest">
-          Download binaries from GitHub
-        </a>
-      </p>
-    </section>
-    <section>
-      <h2>Usage:</h2>
-      <p><em>These examples use <code>235</code> as the command name. If you have just installed it without aliasing or
-          creating symbolic link as shown in install section, you need to call it with <code>nhl-235</code>.</em></p>
-      <h3 id="docs-default">Default</h3>
-      <pre><code>235</code></pre>
-      <div class="output-example">
-        <pre>
+        <h3>- from Github</h3>
+        <p>
+          <a href="https://github.com/Hamatti/nhl-235/releases/latest">
+            Download binaries from GitHub
+          </a>
+        </p>
+      </section>
+      <section>
+        <h2>Usage:</h2>
+        <p>
+          <em
+            >These examples use <code>235</code> as the command name. If you
+            have just installed it without aliasing or creating symbolic link as
+            shown in install section, you need to call it with
+            <code>nhl-235</code>.</em
+          >
+        </p>
+        <h3 id="docs-default">Default</h3>
+        <pre><code>235</code></pre>
+        <div class="output-example">
+          <pre>
 <span class="token-prompt">$</span> 235
 <span class="token-teams">Washington      - Buffalo</span>          <span class="token-final-score">so 4-3</span>
 <span class="token-player">Backström      16 Staal          12</span>
@@ -66,17 +87,21 @@ ln -s ~/.cargo/bin/nhl-235 /usr/local/bin/235</code></pre>
 <span class="token-teams">Pittsburgh      - NY Rangers</span>       1-0
 <span class="token-player">Crosby         14</span>
         </pre>
-      </div>
+        </div>
 
-      <p>With default options, <span class="token-final-score">green score</span> means the game has ended and white
-        that it's still on-going. <span class="token-player">Teal</span> is regular goal and <span
-          class="token-shootout">purple</span> means overtime or shootout winner. The number after scorer's name is the
-        minute of the goal.</p>
+        <p>
+          With default options,
+          <span class="token-final-score">green score</span> means the game has
+          ended and white that it's still on-going.
+          <span class="token-player">Teal</span> is regular goal and
+          <span class="token-shootout">purple</span> means overtime or shootout
+          winner. The number after scorer's name is the minute of the goal.
+        </p>
 
-      <h3 id="docs-nocolors">--nocolors</h3>
-      <pre><code>235 --nocolors</code></pre>
-      <div class="output-example">
-        <pre>
+        <h3 id="docs-nocolors">--nocolors</h3>
+        <pre><code>235 --nocolors</code></pre>
+        <div class="output-example">
+          <pre>
 $ 235 --nocolors
 Washington      - Buffalo          so 4-3
 Backström      16 Staal          12
@@ -86,23 +111,35 @@ Carlson        65
 
 Pittsburgh      - NY Rangers       1-0
 Crosby         14
-            </pre>
-      </div>
-      <p>Running 235 with <code>--nocolors</code> disables printing the color codes to the terminal and everything is
-        default-colored for the terminal.</p>
-      <p>This also happens if printing into anything else than standard output, for example piping into a file or
-        another program.</p>
+            </pre
+          >
+        </div>
+        <p>
+          Running 235 with <code>--nocolors</code> disables printing the color
+          codes to the terminal and everything is default-colored for the
+          terminal.
+        </p>
+        <p>
+          This also happens if printing into anything else than standard output,
+          for example piping into a file or another program.
+        </p>
 
-      <h3 id="docs-highlight">--highlight</h3>
-      <p>You can highlight your favorite players by creating a <code>.235.config</code> file in your home directory.
-        Each line in the file must be a single last name to be highlighted.</p>
-      <p>Example <code>.235.config</code>:</p>
-      <pre><code>Vrana
+        <h3 id="docs-highlight">--highlight</h3>
+        <p>
+          You can highlight your favorite players by creating a
+          <code>.235.config</code> file in your home directory. Each line in the
+          file must be a single last name to be highlighted.
+        </p>
+        <p>Example <code>.235.config</code>:</p>
+        <pre><code>Vrana
 Crosby</code></pre>
-      <p>Once run with <code>--highlight</code> option, those players will be shown in yellow.</p>
-      <pre><code>235 --highlight</code></pre>
-      <div class="output-example">
-        <pre>
+        <p>
+          Once run with <code>--highlight</code> option, those players will be
+          shown in yellow.
+        </p>
+        <pre><code>235 --highlight</code></pre>
+        <div class="output-example">
+          <pre>
 <span class="token-prompt">$</span> 235 --highlight
 <span class="token-teams">Washington      - Buffalo</span>          <span class="token-final-score">so 4-3</span>
 <span class="token-player">Backström      16 Staal          12</span>
@@ -113,23 +150,30 @@ Crosby</code></pre>
 <span class="token-teams">Pittsburgh      - NY Rangers</span>       1-0
 <span class="token-highlight">Crosby         14</span>
                     </pre>
-      </div>
-      <p>This makes it easier for you to see if your favorite players scored.</p>
-      <p><em>If <code>--nocolors</code> is enabled, <code>--highlight</code> does nothing.</em></p>
+        </div>
+        <p>
+          This makes it easier for you to see if your favorite players scored.
+        </p>
+        <p>
+          <em
+            >If <code>--nocolors</code> is enabled,
+            <code>--highlight</code> does nothing.</em
+          >
+        </p>
 
-      <h3 id="docs-version">--version</h3>
+        <h3 id="docs-version">--version</h3>
 
-      <pre><code>235 --version</code></pre>
-      <div class="output-example">
-        <pre><code>1.2.1</code></pre>
-      </div>
+        <pre><code>235 --version</code></pre>
+        <div class="output-example">
+          <pre><code>1.2.1</code></pre>
+        </div>
 
-      <p>Outputs the current version.</p>
+        <p>Outputs the current version.</p>
 
-      <h3 id="docs-help">--help</h3>
-      <pre><code>235 --help</code></pre>
-      <div class="output-example">
-        <pre><code>nhl-235 1.2.1
+        <h3 id="docs-help">--help</h3>
+        <pre><code>235 --help</code></pre>
+        <div class="output-example">
+          <pre><code>nhl-235 1.2.1
 Display live or previous NHL match results on command line
 
 Homepage: https://hamatti.github.io/nhl-235/
@@ -152,38 +196,49 @@ FLAGS:
 
         --version
             Current version</code></pre>
-      </div>
+        </div>
 
-      <p>Prints help information about current version, description of the software and information about options.</p>
+        <p>
+          Prints help information about current version, description of the
+          software and information about options.
+        </p>
+      </section>
 
-    </section>
+      <section>
+        <h2>Source code</h2>
+        <p>235 is published as an open source software with MIT license.</p>
+        <p>
+          You can find the source code from
+          <a href="https://github.com/hamatti/nhl-235/"
+            >https://github.com/hamatti/nhl-235/</a
+          >.
+        </p>
 
-    <section>
-      <h2>Source code</h2>
-      <p>
-        235 is published as an open source software with MIT license.
-      </p>
-      <p>You can find the source code from <a href="https://github.com/hamatti/nhl-235/">https://github.com/hamatti/nhl-235/</a>.</p>
-
-      <p>
-        Feel free to open issues in GitHub if you find bugs or have feature ideas.
-      </p>
-    </section>
-    <section>
-      <h2>Acknowledgements</h2>
-      <p>
-        This software uses <a href="https://github.com/peruukki/nhl-score-api">peruukki/nhl-score-api</a> for its data.
-      </p>
-      <p>
-        Development of 235 has been a grateful recipient of the
-        <a href="https://spiceprogram.org">
-          Futurice Open Source sponsorship program</a> in 2021-2022.
-      </p>
-    </section>
-  </main>
-  <footer>
-    <p>Built with ❤️ by <a href="https://hamatti.org">Juhis</a></p>
-  </footer>
-</body>
-
+        <p>
+          Feel free to open issues in GitHub if you find bugs or have feature
+          ideas.
+        </p>
+      </section>
+      <section>
+        <h2>Acknowledgements</h2>
+        <p>
+          This software uses
+          <a href="https://github.com/peruukki/nhl-score-api"
+            >peruukki/nhl-score-api</a
+          >
+          for its data.
+        </p>
+        <p>
+          Development of 235 has been a grateful recipient of the
+          <a href="https://spiceprogram.org">
+            Futurice Open Source sponsorship program</a
+          >
+          in 2021-2022.
+        </p>
+      </section>
+    </main>
+    <footer>
+      <p>Built with ❤️ by <a href="https://hamatti.org">Juhis</a></p>
+    </footer>
+  </body>
 </html>

--- a/docs/main.css
+++ b/docs/main.css
@@ -1,89 +1,90 @@
 body {
-    background: #1e1d1d;
-    color: white;
-    font-size: 20px;
+  background: #1e1d1d;
+  color: white;
+  font-size: 20px;
 }
 
 header img {
-    margin: auto;
-    max-width: min(800px, 100%);
-    display: block;
+  margin: auto;
+  max-width: min(800px, 100%);
+  display: block;
 }
 
 header,
 main,
 footer {
-    max-width: 800px;
-    margin: auto;
-    display: block;
+  max-width: 800px;
+  margin: auto;
+  display: block;
 }
 
 a,
 a:visited,
 a:hover {
-    color: #52DF45;
+  color: #52df45;
 }
 
 section {
-    border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
 }
 
 h1 {
-    text-align: center;
-    font-size: 2em;
-    margin-bottom: -0.5em;
+  text-align: center;
+  font-size: 2em;
+  margin-bottom: -0.5em;
 }
 
 .tagline {
-    font-size: 0.8em;
-    text-align: center;
+  font-size: 0.8em;
+  text-align: center;
 }
 
 pre {
-    line-height: 1.5;
-    background: #424242;
-    counter-reset: linenumber;
-    overflow: auto;
-    font-size: min(3vw, 20px);
-    border: 1px solid #fff;
-    padding: 0.5em;
-    border-radius: 10px;
+  line-height: 1.5;
+  background: #424242;
+  counter-reset: linenumber;
+  overflow: auto;
+  font-size: min(3vw, 20px);
+  border: 1px solid #fff;
+  padding: 0.5em;
+  border-radius: 10px;
 }
 
 @media screen and (max-width: 800px) {
-    body {
-        font-size: 18px;
-        margin: 1em;
-    }
+  body {
+    font-size: 18px;
+    margin: 1em;
+  }
 }
 
 .output-example pre {
-    background-color: black;
+  background-color: black;
 }
 
 .token-final-score {
-    color: greenyellow;
+  color: greenyellow;
 }
 
 .token-player {
-    color: rgb(15, 221, 221);
+  color: rgb(15, 221, 221);
 }
 
 .token-shootout {
-    color: rgb(206, 42, 206);
+  color: rgb(206, 42, 206);
 }
 
 p code {
-    font-size: 0.8em;
-    background: #424242;
-    padding: 0.2em;
-    border-radius: 10px;
+  font-size: 0.8em;
+  background: #424242;
+  padding: 0.2em;
+  border-radius: 10px;
 }
 
-.token-highlight {
-    color: yellow;
+.token-highlight,
+.token-stats {
+  color: yellow;
 }
 
 footer {
-    text-align: center;
+  text-align: center;
 }

--- a/docs/release-notes/1.3.0.html
+++ b/docs/release-notes/1.3.0.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release notes for version 1.3.0 of nhl-235</title>
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap"
+      rel="stylesheet"
+    />
+
+    <meta property="og:title" content="235 - Release notes for 1.3.0" />
+    <meta
+      property="og:url"
+      content="https://hamatti.github.io/nhl-235/release-notes/1.3.0"
+    />
+    <meta
+      property="og:description"
+      content="What's new in version 1.3.0 of nhl-235?"
+    />
+    <meta
+      property="og:image"
+      content="https://hamatti.github.io/nhl-235-banner.png"
+    />
+
+    <link rel="stylesheet" href="../main.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Release notes for version 1.3.0</h1>
+
+      <section>
+        <h2>Goals + assists for followed players</h2>
+
+        <p>
+          Starting with version 1.3.0, users can now see more stats from the
+          players they follow.
+        </p>
+        <p>
+          You can follow players by adding their last name to file
+          <code>$HOME/.235.config</code>. Previously, this allowed users to
+          highlight them in yellow color with the flag <code>--highlight</code>.
+        </p>
+        <h3>Stats with <code>--highlight</code></h3>
+        <p>
+          Now, you can use <code>--stats</code> flag to show the goals and
+          assists of those players underneath the full game summary.
+        </p>
+
+        <div class="output-example">
+          <pre>
+            <span class="token-prompt">$</span> 235 --highlight --stats
+            <span class="token-teams">Washington      - Buffalo</span>          <span class="token-final-score">so 4-3</span>
+            <span class="token-player">Backström      16 Staal          12</span>
+            <span class="token-player">Dowd           24</span> <span class="token-highlight">Cozens         30</span>
+            <span class="token-highlight">Vrana          33</span> <span class="token-player">Sheahan        33</span>
+            <span class="token-shootout">Carlson        65</span>
+
+            <span class="token-stats">(Vrana 1+2, Cozens 1+0)</span>
+
+            <span class="token-teams">Pittsburgh      - NY Rangers</span>       1-0
+            <span class="token-highlight">Crosby         14</span>
+
+            <span class="token-stats">(Crosby 1+0)</span>
+        </pre>
+        </div>
+
+        <h3>Stats without <code>--highlight</code></h3>
+        <p>
+          You can use <code>--stats</code> also without
+          <code>--highlight</code> in which case you'll see the stats but
+          without yellow highlight.
+        </p>
+        <div class="output-example">
+          <pre>
+            <span class="token-prompt">$</span> 235 --stats
+            <span class="token-teams">Washington      - Buffalo</span>          <span class="token-final-score">so 4-3</span>
+            <span class="token-player">Backström      16 Staal          12</span>
+            <span class="token-player">Dowd           24</span> <span class="token-player">Cozens         30</span>
+            <span class="token-player">Vrana          33</span> <span class="token-player">Sheahan        33</span>
+            <span class="token-shootout">Carlson        65</span>
+
+            <span class="token-player">(Vrana 1+2, Cozens 1+0)</span>
+
+            <span class="token-teams">Pittsburgh      - NY Rangers</span>       1-0
+            <span class="token-player">Crosby         14</span>
+
+            <span class="token-player">(Crosby 1+0)</span>
+        </pre>
+        </div>
+
+        <h3>FAQ</h3>
+        <h4>What if no <code>$HOME/.235.config</code> is not defined?</h4>
+        <p>
+          If you haven't defined any entries in the highlights file,
+          <code>--stats</code> will be ignored.
+        </p>
+        <h4>Will players with 0+0 stats be shown?</h4>
+        <p>
+          No. It adds too much clutter and makes it harder to find stats that
+          matter.
+        </p>
+
+        <h3>Update instructions</h3>
+        <p>
+          If you have installed 235 through
+          <a href="https://crates.io/crates/nhl-235">Cargo</a>, you can update
+          your package to 1.3.0 with <code>cargo update nhl-235</code>.
+        </p>
+        <p>
+          If you have downloaded a binary from
+          <a href="https://github.com/Hamatti/nhl-235">GitHub</a>, you can
+          download
+          <a href="https://github.com/Hamatti/nhl-235/releases/tag/v1.3.0"
+            >1.3.0</a
+          >
+          binary there and replace your old file.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -515,34 +515,24 @@ fn print_away_goal(away: &Goal, use_colors: bool, highlights: &[String], show_hi
 
 fn count_stats(goal: &Goal, stats: &mut HashMap<String, Stat>, highlights: &[String]) {
     if highlights.contains(&goal.scorer) {
-        let new_stat = match stats.get(&goal.scorer) {
-            Some(stat) => Stat {
-                goals: stat.goals + 1,
-                assists: stat.assists,
-            },
-            None => Stat {
+        stats
+            .entry(String::from(&goal.scorer))
+            .and_modify(|stat| stat.goals += 1)
+            .or_insert(Stat {
                 goals: 1,
                 assists: 0,
-            },
-        };
-
-        stats.insert(String::from(&goal.scorer), new_stat);
+            });
     }
 
     goal.assists.iter().for_each(|assist| {
         if highlights.contains(&assist) {
-            let new_stat = match stats.get(&goal.scorer) {
-                Some(stat) => Stat {
-                    goals: stat.goals,
-                    assists: stat.assists + 1,
-                },
-                None => Stat {
+            stats
+                .entry(String::from(assist))
+                .and_modify(|stat| stat.assists += 1)
+                .or_insert(Stat {
                     goals: 0,
                     assists: 1,
-                },
-            };
-
-            stats.insert(String::from(assist), new_stat);
+                });
         }
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,9 +529,14 @@ fn count_stats<'a>(
 }
 
 fn has_last_name_namesake(player: &Player, stats: &HashMap<&Player, Stat>) -> bool {
-    for key in stats.keys() {
-        if key.last_name == player.last_name && key.team != player.team {
+    for other in stats.keys() {
+        if other.last_name == player.last_name && other.team != player.team {
             return true;
+        }
+        if other.last_name == player.last_name && other.team == player.team {
+            if other.first_name != player.first_name {
+                return true;
+            }
         }
     }
     false
@@ -1173,7 +1178,7 @@ mod tests {
     }
 
     #[test]
-    fn it_crafts_good_message_if_different_players_with_same_last_name() {
+    fn it_crafts_good_message_if_different_players_from_different_teams_with_same_last_name() {
         let highlights: Vec<String> = vec![String::from("Hughes")];
         let goal: Goal = Goal {
             scorer: Player {
@@ -1197,6 +1202,41 @@ mod tests {
             minute: 23,
             special: false,
             team: String::from("Vancouver"),
+        };
+
+        let expected: String = String::from("Q. Hughes 1+0");
+        let expected2: String = String::from("J. Hughes 1+0");
+        let actual: Option<String> = craft_stats_message(&vec![goal, goal2], &highlights);
+
+        assert_eq!(actual.as_ref().unwrap().contains(&expected), true);
+        assert_eq!(actual.as_ref().unwrap().contains(&expected2), true);
+    }
+
+    #[test]
+    fn it_crafts_good_message_if_different_players_from_same_team_with_same_last_name() {
+        let highlights: Vec<String> = vec![String::from("Hughes")];
+        let goal: Goal = Goal {
+            scorer: Player {
+                first_name: String::from("Jack"),
+                last_name: String::from("Hughes"),
+                team: String::from("New Jersey"),
+            },
+            assists: vec![],
+            minute: 21,
+            special: false,
+            team: String::from("New Jersey"),
+        };
+
+        let goal2: Goal = Goal {
+            scorer: Player {
+                first_name: String::from("Quinn"),
+                last_name: String::from("Hughes"),
+                team: String::from("New Jersey"),
+            },
+            assists: vec![],
+            minute: 23,
+            special: false,
+            team: String::from("New Jersey"),
         };
 
         let expected: String = String::from("Q. Hughes 1+0");

--- a/src/main.rs
+++ b/src/main.rs
@@ -513,6 +513,40 @@ fn print_away_goal(away: &Goal, use_colors: bool, highlights: &[String], show_hi
     }
 }
 
+fn count_stats(goal: &Goal, stats: &mut HashMap<String, Stat>, highlights: &[String]) {
+    if highlights.contains(&goal.scorer) {
+        let new_stat = match stats.get(&goal.scorer) {
+            Some(stat) => Stat {
+                goals: stat.goals + 1,
+                assists: stat.assists,
+            },
+            None => Stat {
+                goals: 1,
+                assists: 0,
+            },
+        };
+
+        stats.insert(String::from(&goal.scorer), new_stat);
+    }
+
+    goal.assists.iter().for_each(|assist| {
+        if highlights.contains(&assist) {
+            let new_stat = match stats.get(&goal.scorer) {
+                Some(stat) => Stat {
+                    goals: stat.goals,
+                    assists: stat.assists + 1,
+                },
+                None => Stat {
+                    goals: 0,
+                    assists: 1,
+                },
+            };
+
+            stats.insert(String::from(assist), new_stat);
+        }
+    })
+}
+
 fn print_stats(
     home_scores: &Vec<&Goal>,
     away_scores: &Vec<&Goal>,
@@ -520,80 +554,13 @@ fn print_stats(
     show_highlights: bool,
 ) {
     let mut stats: HashMap<String, Stat> = HashMap::new();
+
     home_scores.iter().for_each(|&goal| {
-        if highlights.contains(&goal.scorer) {
-            let current_stats = match stats.get(&goal.scorer) {
-                Some(stat) => stat,
-                None => &Stat {
-                    goals: 0,
-                    assists: 0,
-                },
-            };
-
-            let new_stat: Stat = Stat {
-                goals: current_stats.goals + 1,
-                assists: current_stats.assists,
-            };
-
-            stats.insert(String::from(&goal.scorer), new_stat);
-        }
-
-        goal.assists.iter().for_each(|assist| {
-            if highlights.contains(&assist) {
-                let current_stats = match stats.get(&goal.scorer) {
-                    Some(stat) => stat,
-                    None => &Stat {
-                        goals: 0,
-                        assists: 0,
-                    },
-                };
-
-                let new_stat: Stat = Stat {
-                    goals: current_stats.goals,
-                    assists: current_stats.assists + 1,
-                };
-
-                stats.insert(String::from(assist), new_stat);
-            }
-        })
+        count_stats(&goal, &mut stats, &highlights);
     });
 
     away_scores.iter().for_each(|&goal| {
-        if highlights.contains(&goal.scorer) {
-            let current_stats = match stats.get(&goal.scorer) {
-                Some(stat) => stat,
-                None => &Stat {
-                    goals: 0,
-                    assists: 0,
-                },
-            };
-
-            let new_stat: Stat = Stat {
-                goals: current_stats.goals + 1,
-                assists: current_stats.assists,
-            };
-
-            stats.insert(String::from(&goal.scorer), new_stat);
-        }
-
-        goal.assists.iter().for_each(|assist| {
-            if highlights.contains(&assist) {
-                let current_stats = match stats.get(&goal.scorer) {
-                    Some(stat) => stat,
-                    None => &Stat {
-                        goals: 0,
-                        assists: 0,
-                    },
-                };
-
-                let new_stat: Stat = Stat {
-                    goals: current_stats.goals,
-                    assists: current_stats.assists + 1,
-                };
-
-                stats.insert(String::from(assist), new_stat);
-            }
-        })
+        count_stats(&goal, &mut stats, &highlights);
     });
 
     if stats.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,36 +494,37 @@ fn print_away_goal(away: &Goal, highlights: &[String], options: &Options) {
     }
 }
 
-fn count_stats(goal: &Goal, stats: &mut HashMap<String, Stat>, highlights: &[String]) {
-    if highlights.contains(&goal.scorer) {
-        stats
-            .entry(String::from(&goal.scorer))
-            .and_modify(|stat| stat.goals += 1)
-            .or_insert(Stat {
-                goals: 1,
-                assists: 0,
-            });
-    }
-
-    goal.assists.iter().for_each(|assist| {
-        if highlights.contains(&assist) {
-            stats
-                .entry(String::from(assist))
-                .and_modify(|stat| stat.assists += 1)
-                .or_insert(Stat {
-                    goals: 0,
-                    assists: 1,
-                });
-        }
-    })
-}
-
-fn print_stats(goals: &Vec<Goal>, highlights: &[String], options: &Options) {
+fn count_stats(goals: &Vec<Goal>, highlights: &[String]) -> HashMap<String, Stat> {
     let mut stats: HashMap<String, Stat> = HashMap::new();
 
     goals.iter().for_each(|goal| {
-        count_stats(&goal, &mut stats, &highlights);
+        if highlights.contains(&goal.scorer) {
+            stats
+                .entry(String::from(&goal.scorer))
+                .and_modify(|stat| stat.goals += 1)
+                .or_insert(Stat {
+                    goals: 1,
+                    assists: 0,
+                });
+        }
+        goal.assists.iter().for_each(|assist| {
+            if highlights.contains(&assist) {
+                stats
+                    .entry(String::from(assist))
+                    .and_modify(|stat| stat.assists += 1)
+                    .or_insert(Stat {
+                        goals: 0,
+                        assists: 1,
+                    });
+            }
+        })
     });
+
+    return stats;
+}
+
+fn print_stats(goals: &Vec<Goal>, highlights: &[String], options: &Options) {
+    let stats: HashMap<String, Stat> = count_stats(&goals, &highlights);
 
     if stats.is_empty() {
         return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,19 +522,17 @@ fn print_stats(
     let mut stats: HashMap<String, Stat> = HashMap::new();
     home_scores.iter().for_each(|&goal| {
         if highlights.contains(&goal.scorer) {
-            let current_score = match stats.get(&goal.scorer) {
-                Some(stat) => stat.goals,
-                None => 0,
-            };
-
-            let current_assists = match stats.get(&goal.scorer) {
-                Some(stat) => stat.assists,
-                None => 0,
+            let current_stats = match stats.get(&goal.scorer) {
+                Some(stat) => stat,
+                None => &Stat {
+                    goals: 0,
+                    assists: 0,
+                },
             };
 
             let new_stat: Stat = Stat {
-                goals: current_score + 1,
-                assists: current_assists,
+                goals: current_stats.goals + 1,
+                assists: current_stats.assists,
             };
 
             stats.insert(String::from(&goal.scorer), new_stat);
@@ -542,19 +540,17 @@ fn print_stats(
 
         goal.assists.iter().for_each(|assist| {
             if highlights.contains(&assist) {
-                let current_goals = match stats.get(assist) {
-                    Some(stat) => stat.goals,
-                    None => 0,
-                };
-
-                let current_assists = match stats.get(assist) {
-                    Some(stat) => stat.assists,
-                    None => 0,
+                let current_stats = match stats.get(&goal.scorer) {
+                    Some(stat) => stat,
+                    None => &Stat {
+                        goals: 0,
+                        assists: 0,
+                    },
                 };
 
                 let new_stat: Stat = Stat {
-                    goals: current_goals,
-                    assists: current_assists + 1,
+                    goals: current_stats.goals,
+                    assists: current_stats.assists + 1,
                 };
 
                 stats.insert(String::from(assist), new_stat);
@@ -564,19 +560,17 @@ fn print_stats(
 
     away_scores.iter().for_each(|&goal| {
         if highlights.contains(&goal.scorer) {
-            let current_goals = match stats.get(&goal.scorer) {
-                Some(stat) => stat.goals,
-                None => 0,
-            };
-
-            let current_assists = match stats.get(&goal.scorer) {
-                Some(stat) => stat.assists,
-                None => 0,
+            let current_stats = match stats.get(&goal.scorer) {
+                Some(stat) => stat,
+                None => &Stat {
+                    goals: 0,
+                    assists: 0,
+                },
             };
 
             let new_stat: Stat = Stat {
-                goals: current_goals + 1,
-                assists: current_assists,
+                goals: current_stats.goals + 1,
+                assists: current_stats.assists,
             };
 
             stats.insert(String::from(&goal.scorer), new_stat);
@@ -584,19 +578,17 @@ fn print_stats(
 
         goal.assists.iter().for_each(|assist| {
             if highlights.contains(&assist) {
-                let current_goals = match stats.get(assist) {
-                    Some(stat) => stat.goals,
-                    None => 0,
-                };
-
-                let current_assists = match stats.get(assist) {
-                    Some(stat) => stat.assists,
-                    None => 0,
+                let current_stats = match stats.get(&goal.scorer) {
+                    Some(stat) => stat,
+                    None => &Stat {
+                        goals: 0,
+                        assists: 0,
+                    },
                 };
 
                 let new_stat: Stat = Stat {
-                    goals: current_goals,
-                    assists: current_assists + 1,
+                    goals: current_stats.goals,
+                    assists: current_stats.assists + 1,
                 };
 
                 stats.insert(String::from(assist), new_stat);
@@ -608,18 +600,17 @@ fn print_stats(
         return;
     }
 
-    let mut message = String::from("(");
+    let mut stats_messages: Vec<String> = Vec::new();
     for (name, stats) in stats.iter() {
-        message.push_str(name);
-        message.push_str(" ");
-        message.push_str(&stats.goals.to_string());
-        message.push_str("+");
-        message.push_str(&stats.assists.to_string());
-        message.push_str(", ");
+        let sub_message = format!(
+            "{} {}+{}",
+            name,
+            &stats.goals.to_string(),
+            &stats.assists.to_string()
+        );
+        stats_messages.push(sub_message);
     }
-    let len = message.len();
-    message = String::from(&message[..len - 2]);
-    message.push_str(")");
+    let message: String = format!("({})", stats_messages.join(", "));
 
     if show_highlights {
         yellow_ln!("{}", message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,7 +426,7 @@ fn print_game(
     println!();
 
     if show_stats {
-        print_stats(&home_scores, &away_scores, &highlights, show_highlights);
+        print_stats(&game.goals, &highlights, show_highlights);
     }
 
     match &game.playoff_series {
@@ -537,19 +537,10 @@ fn count_stats(goal: &Goal, stats: &mut HashMap<String, Stat>, highlights: &[Str
     })
 }
 
-fn print_stats(
-    home_scores: &Vec<&Goal>,
-    away_scores: &Vec<&Goal>,
-    highlights: &[String],
-    show_highlights: bool,
-) {
+fn print_stats(goals: &Vec<Goal>, highlights: &[String], show_highlights: bool) {
     let mut stats: HashMap<String, Stat> = HashMap::new();
 
-    home_scores.iter().for_each(|&goal| {
-        count_stats(&goal, &mut stats, &highlights);
-    });
-
-    away_scores.iter().for_each(|&goal| {
+    goals.iter().for_each(|goal| {
         count_stats(&goal, &mut stats, &highlights);
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,9 +86,6 @@ struct Cli {
 
 fn main() {
     let args = Cli::from_args();
-    // Using an inverse here because default is colors enabled
-    // and I want to keep the API easier to read down the line,
-    // hence colors need to be enabled rather than disabled
     if args.version {
         println!("{}", env!("CARGO_PKG_VERSION"));
         std::process::exit(0);
@@ -97,6 +94,9 @@ fn main() {
     let highlights = read_highlight_config().unwrap_or_default();
 
     let options: Options = Options {
+        // Using an inverse here because default is colors enabled
+        // and I want to keep the API easier to read down the line,
+        // hence colors need to be enabled rather than disabled
         use_colors: !args.nocolors,
         show_stats: args.stats,
         show_highlights: args.highlight,

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn print_game(game: &Game, highlights: &[String], options: &Options) {
     }
     println!();
 
-    if options.show_stats {
+    if options.show_stats && !highlights.is_empty() {
         print_stats(&game.goals, &highlights, &options);
     }
 


### PR DESCRIPTION
Starting with version 1.3.0, users can now see more stats from the players they follow.

You can follow players by adding their last name to file $HOME/.235.config. Previously, this allowed users to highlight them in yellow color with the flag --highlight.


## Stats with --highlight

Now, you can use --stats flag to show the goals and assists of those players underneath the full game summary.

(highlight not shown on GitHub)

```
$ cat ~/.235.config
Vrana
Cozens
Crosby

$ 235 --highlight --stats
Washington      - Buffalo          so 4-3
Backström      16 Staal          12
Dowd           24 Cozens         30
Vrana          33 Sheahan        33
Carlson        65

(Vrana 1+2, Cozens 1+0)

Pittsburgh      - NY Rangers       1-0
Crosby         14

(Crosby 1+0)
```

Stats without --highlight

You can use --stats also without --highlight in which case you'll see the stats but without yellow highlight.
```
$ cat ~/.235.config
Vrana
Cozens
Crosby

$ 235 --stats
Washington      - Buffalo          so 4-3
Backström      16 Staal          12
Dowd           24 Cozens         30
Vrana          33 Sheahan        33
Carlson        65

(Vrana 1+2, Cozens 1+0)

Pittsburgh      - NY Rangers       1-0
Crosby         14

(Crosby 1+0)
```

## FAQ
- **What if no $HOME/.235.config is not defined?**
If you haven't defined any entries in the highlights file, --stats will be ignored.

- **Will players with 0+0 stats be shown?**
No. It adds too much clutter and makes it harder to find stats that matter.


Implements #43 