### PR TITLE
Wrap long stat highlight lines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.1 - 2024-01-22
+
+### Fixed
+
+- Wrap highlight string if it's very long.
+
 ## 1.3.0 - 2023-10-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
A first functioning attempt at wrapping long lines.

Might require still some fine-tuning for better recognition of the right spot to wrap.

Fixes #50 

Before:
![overflow](https://github.com/Hamatti/nhl-235/assets/1909996/2e663e88-052f-44d3-82c2-74e6e73a0ffd)

After:
![overflow-fixed](https://github.com/Hamatti/nhl-235/assets/1909996/18b7e2cc-7450-47e0-b1cb-4f860849257c)
