### PR TITLE
Add Utah Hockey Club

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.0 - 2024-10-08
+
+### Changed
+
+- Remove Arizona Coyotes
+- Add Utah Hockey Club
+
 ## 1.3.0 - 2023-10-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -54,6 +54,7 @@
         <h2>Release notes</h2>
 
         <ul class="release-notes">
+          <li><a href="release-notes/1.4.0">version 1.4.0</a></li>
           <li><a href="release-notes/1.3.0">version 1.3.0</a></li>
         </ul>
       </section>

--- a/docs/release-notes/1.4.0.html
+++ b/docs/release-notes/1.4.0.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release notes for version 1.4.0 of nhl-235</title>
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap"
+      rel="stylesheet"
+    />
+
+    <meta property="og:title" content="235 - Release notes for 1.4.0" />
+    <meta
+      property="og:url"
+      content="https://hamatti.github.io/nhl-235/release-notes/1.4.0"
+    />
+    <meta
+      property="og:description"
+      content="What's new in version 1.4.0 of nhl-235?"
+    />
+    <meta
+      property="og:image"
+      content="https://hamatti.github.io/nhl-235-banner.png"
+    />
+
+    <link rel="stylesheet" href="../main.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Release notes for version 1.4.0</h1>
+
+      <section>
+        <h2>Arizona Coyotes out, Utah Hockey Club in</h2>
+        <p>
+          As the 2024-2025 season starts, we're seeing changes in teams. Arizona
+          Coyotes has left the league and relocated to Utah.
+        </p>
+        <h3>Update instructions</h3>
+        <p>
+          If you have installed 235 through
+          <a href="https://crates.io/crates/nhl-235">Cargo</a>, you can update
+          your package to 1.4.0 with <code>cargo install nhl-235</code>.
+        </p>
+        <p>
+          If you have downloaded a binary from
+          <a href="https://github.com/Hamatti/nhl-235">GitHub</a>, you can
+          download
+          <a href="https://github.com/Hamatti/nhl-235/releases/tag/v1.4.0"
+            >1.4.0</a
+          >
+          binary there and replace your old file.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,6 @@ fn translate_team_name(abbr: &str) -> String {
         "NSH" => "Nashville",
         "TBL" => "Tampa Bay",
         "ANA" => "Anaheim",
-        "ARI" => "Arizona",
         "COL" => "Colorado",
         "LAK" => "Los Angeles",
         "MIN" => "Minnesota",
@@ -191,6 +190,7 @@ fn translate_team_name(abbr: &str) -> String {
         "VAN" => "Vancouver",
         "WPG" => "Winnipeg",
         "SEA" => "Seattle",
+        "UTA" => "Utah",
         _ => "[unknown]",
     };
 


### PR DESCRIPTION
Remove support for Arizona Coyotes and add support to display Utah Hockey Club correctly as Utah.