### PR TITLE
Fix: Don't count shootout goals as goals in stats

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.1 - 2024-12-11
+
+### Fixed
+
+- Fixed a bug that calculated shootout goals to player's goal stat when using `--stat`
+
 ## 1.4.0 - 2024-10-08
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "nhl-235"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "atty",
  "colour",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhl-235"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Juha-Matti Santala <juhamattisantala@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -54,6 +54,7 @@
         <h2>Release notes</h2>
 
         <ul class="release-notes">
+          <li><a href="release-notes/1.4.1">version 1.4.1</a></li>
           <li><a href="release-notes/1.4.0">version 1.4.0</a></li>
           <li><a href="release-notes/1.3.0">version 1.3.0</a></li>
         </ul>

--- a/docs/release-notes/1.4.1.html
+++ b/docs/release-notes/1.4.1.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Release notes for version 1.4.1 of nhl-235</title>
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap"
+      rel="stylesheet"
+    />
+
+    <meta property="og:title" content="235 - Release notes for 1.4.1" />
+    <meta
+      property="og:url"
+      content="https://hamatti.github.io/nhl-235/release-notes/1.4.1"
+    />
+    <meta
+      property="og:description"
+      content="What's new in version 1.4.1 of nhl-235?"
+    />
+    <meta
+      property="og:image"
+      content="https://hamatti.github.io/nhl-235-banner.png"
+    />
+
+    <link rel="stylesheet" href="../main.css" />
+  </head>
+  <body>
+    <main>
+      <h1>Release notes for version 1.4.1</h1>
+
+      <section>
+        <h2>Fixed a bug in <code>--stats</code> goal calculation</h2>
+        <p>
+          In 1.4.0, when running the app with <code>--stats</code> flag,
+          shootout goals were incorrectly counted in to player's goal count.
+        </p>
+        <h3>Update instructions</h3>
+        <p>
+          If you have installed 235 through
+          <a href="https://crates.io/crates/nhl-235">Cargo</a>, you can update
+          your package to 1.4.1 with <code>cargo install nhl-235</code>.
+        </p>
+        <p>
+          If you have downloaded a binary from
+          <a href="https://github.com/Hamatti/nhl-235">GitHub</a>, you can
+          download
+          <a href="https://github.com/Hamatti/nhl-235/releases/tag/v1.4.1"
+            >1.4.1</a
+          >
+          binary there and replace your old file.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
When running 235 with `--stats` flag, the software counted all goals. However, in hockey, the shootout goals are not counted towards player's goal stat so let's not do it here either.